### PR TITLE
fix drag/resize disapper after responsive

### DIFF
--- a/src/components/Grid/GridLayout.vue
+++ b/src/components/Grid/GridLayout.vue
@@ -243,6 +243,7 @@
 
     // new prop sync
     // noinspection TypeScriptValidateTypes
+    originalLayout.value = layout;
     emit(EGridLayoutEvent.UPDATE_LAYOUT, layout);
 
     lastBreakpoint.value = newBreakpoint;
@@ -330,6 +331,7 @@
     updateHeight();
     if(eventName === EDragEvent.DRAG_END) {
       positionsBeforeDrag.value = undefined;
+      originalLayout.value = layout;
       emit(EGridLayoutEvent.LAYOUT_UPDATED, layout);
     }
   };
@@ -406,6 +408,7 @@
     updateHeight();
 
     if(eventName === `resizeend`) {
+      originalLayout.value = props.layout;
       emit(EGridLayoutEvent.LAYOUT_UPDATED, props.layout);
     }
   };
@@ -499,6 +502,7 @@
       compactLayout(props.layout, props.verticalCompact);
       eventBus.emit(`updateWidth`, width.value);
       updateHeight();
+      originalLayout.value = props.layout;
       emit(EGridLayoutEvent.LAYOUT_UPDATED, props.layout);
     }
   };

--- a/src/core/helpers/responsiveUtils.ts
+++ b/src/core/helpers/responsiveUtils.ts
@@ -163,30 +163,10 @@ export const findOrGenerateResponsiveLayout = (
   verticalCompact: boolean,
   distributeEvenly: boolean,
 ): TLayout => {
-  // If it already exists, just return it.
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  if(layouts[breakpoint] && !distributeEvenly) {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    return cloneLayout(layouts[breakpoint]);
-  }
-  // Find or generate the next layout
-  let layout = orgLayout;
+  // we cant return the layouts[breakpoints] directly because we dunno whether user change the layout or not
 
-  const breakpointsSorted = sortBreakpoints(breakpoints);
-  const breakpointsAbove = breakpointsSorted.slice(breakpointsSorted.indexOf(breakpoint));
-  for(let i = 0, len = breakpointsAbove.length; i < len; i++) {
-    const b = breakpointsAbove[i];
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    if(layouts[b]) {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      layout = layouts[b];
-      break;
-    }
-  }
-  layout = cloneLayout(layout || []); // clone layout so we don't modify existing items
+  // Find or generate the next layout
+  const layout = cloneLayout(orgLayout || []);
+
   return compactLayout(correctBounds(layout, { cols }, distributeEvenly), verticalCompact);
 };


### PR DESCRIPTION
# Description

we can't return the layout in the layouts array directly because layout may have changed.

remove the part that gets the layout from the layout array, always use the orgLayout to generate the new responsive layout instead.

Fixes #16 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
