### PR TITLE
fix the problem if layout doesnt have static item

### DIFF
--- a/src/core/helpers/utils.ts
+++ b/src/core/helpers/utils.ts
@@ -70,9 +70,12 @@ export function collides(l1: ILayoutItem, l2: ILayoutItem): boolean {
  * @throws {Error}                  Empty layout.
  */
 export function getFirstCollision(layout: TLayout, layoutItem: ILayoutItem): ILayoutItem | undefined {
-  if(layout.length < 1) {
-    throw new Error('Empty layout');
-  }
+  // if layout doesnt have static item it will cause error
+  // cannot drag or do anything
+
+  // if(layout.length < 1) {
+  //   throw new Error('Empty layout');
+  // }
 
   for(let i = 0, len = layout.length; i < len; i++) {
     if(collides(layout[i], layoutItem)) {


### PR DESCRIPTION
# Description

if layout doesn't have static item, it will throw a error about the layout is empty.
the example layout is the following:
```
{ h: 1, i: 1, w: 1, x: 0, y: 0 },
{ h: 1, i: 2, w: 1, x: 1, y: 0 },
{ h: 1, i: 3, w: 1, x: 2, y: 0 },
{ h: 1, i: 4, w: 1, x: 3, y: 0 },
{ h: 1, i: 5, w: 1, x: 4, y: 0 },
{ h: 1, i: 6, w: 1, x: 0, y: 1 },
{ h: 1, i: 7, w: 1, x: 1, y: 1 },
{ h: 1, i: 8, w: 1, x: 2, y: 1 },
```

it will cause error and prevent all action.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
