### PR TITLE
responsiveGridLayout returns cache if called by resize

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vue-ts-responsive-grid-layout",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vue-ts-responsive-grid-layout",
-      "version": "1.2.6",
+      "version": "1.2.7",
       "license": "MIT",
       "dependencies": {
         "@interactjs/actions": "^1.10.17",

--- a/src/components/Grid/GridLayout.vue
+++ b/src/components/Grid/GridLayout.vue
@@ -20,20 +20,20 @@
   </div>
 </template>
 <script lang="ts">
-import {
-  computed,
-  defineComponent,
-  nextTick,
-  onBeforeMount,
-  onBeforeUnmount,
-  onMounted,
-  provide,
-  ref,
-  toRef,
-  watch,
-} from 'vue';
+  import {
+    computed,
+    defineComponent,
+    nextTick,
+    onBeforeMount,
+    onBeforeUnmount,
+    onMounted,
+    provide,
+    ref,
+    toRef,
+    watch,
+  } from 'vue';
 
-export default defineComponent({
+  export default defineComponent({
     name: `GridLayout`,
   });
 
@@ -62,9 +62,9 @@ export default defineComponent({
   } from '@/core/helpers/responsiveUtils';
   import { addWindowEventListener, removeWindowEventListener } from '@/core/helpers/DOM';
   import { EGridLayoutEvent } from '@/core/enums/EGridLayoutEvents';
-  import {IBreakpoints, IColumns, IGridLayoutProps} from './grid-layout-props.interface';
+  import { IBreakpoints, IColumns, IGridLayoutProps } from './grid-layout-props.interface';
   import { IEventsData } from '@/core/interfaces/eventBus.interfaces';
-  import {EDragEvent} from "@/core/enums/EDragEvent";
+  import { EDragEvent } from '@/core/enums/EDragEvent';
 
   export interface IGridLayoutProps {
     autoSize?: boolean;
@@ -214,7 +214,7 @@ export default defineComponent({
   };
 
   // finds or generates new layouts for set breakpoints
-  const responsiveGridLayout = (): void => {
+  const responsiveGridLayout = (windowResize = false): void => {
     const newBreakpoint = getBreakpointFromWidth(props.breakpoints, width.value as number);
     const newCols = getColsFromBreakpoint(newBreakpoint, props.cols);
     // responsive cols
@@ -224,6 +224,14 @@ export default defineComponent({
     // max is colNum which is set by user
     if(colNum.value < colNumResponsive.value) {
       colsCompute = colNum.value;
+    }
+
+    if(windowResize && layouts.value[newBreakpoint]) {
+      originalLayout.value = layouts.value[newBreakpoint];
+      emit(EGridLayoutEvent.LAYOUT_UPDATE, layouts.value[newBreakpoint]);
+      lastBreakpoint.value = newBreakpoint;
+      eventBus.emit(`setColNum`, colsCompute);
+      return;
     }
 
     if(lastBreakpoint.value != null && !layouts.value[lastBreakpoint.value]) {
@@ -250,10 +258,9 @@ export default defineComponent({
 
     // new prop sync
     // noinspection TypeScriptValidateTypes
+
     originalLayout.value = layout;
-
     emit(EGridLayoutEvent.LAYOUT_UPDATE, layout);
-
     lastBreakpoint.value = newBreakpoint;
     eventBus.emit(`setColNum`, colsCompute);
   };
@@ -290,7 +297,7 @@ export default defineComponent({
       emit(EGridLayoutEvent.DRAG_START, 1);
     }
 
-    switch (eventName) {
+    switch(eventName) {
       case EDragEvent.DRAG_END: {
         emit(EGridLayoutEvent.DRAG_END, id ?? 0);
         break;
@@ -329,8 +336,7 @@ export default defineComponent({
           isDragging.value = false;
         });
       }
-    }
-    else {
+    } else {
       nextTick(() => {
         isDragging.value = false;
       });
@@ -356,7 +362,7 @@ export default defineComponent({
     if(eventName !== undefined && eventName === EGridLayoutEvent.DRAG_END) {
       positionsBeforeDrag.value = undefined;
       originalLayout.value = layout;
-      emit(EGridLayoutEvent.DRAG_END,1);
+      emit(EGridLayoutEvent.DRAG_END, 1);
       emit(EGridLayoutEvent.LAYOUT_UPDATED, layout);
     }
   };
@@ -541,7 +547,7 @@ export default defineComponent({
     }
 
     if(props.responsive) {
-      responsiveGridLayout();
+      responsiveGridLayout(true);
     }
     eventBus.emit(`resizeEvent`);
   };

--- a/src/core/helpers/responsiveUtils.ts
+++ b/src/core/helpers/responsiveUtils.ts
@@ -188,27 +188,8 @@ export const findOrGenerateResponsiveLayout = (
   distributeEvenly: boolean,
 ): TLayout => {
   // we cant return the layouts[breakpoints] directly because we don't know whether user change the layout or not
-  if(breakpoint && layouts[breakpoint as keyof typeof layouts] && !distributeEvenly) {
-    return cloneLayout(layouts[breakpoint as keyof typeof layouts]!);
-  }
   // Find or generate the next layout
-  let layout = cloneLayout(orgLayout || []);
-
-  const breakpointsSorted = sortBreakpoints(breakpoints);
-  const breakpointsAbove = breakpointsSorted.slice(breakpointsSorted.indexOf(breakpoint));
-  for(let i = 0, len = breakpointsAbove.length; i < len; i++) {
-    const b = breakpointsAbove[i];
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    if(layouts[b]) {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      layout = layouts[b];
-      break;
-    }
-  }
-
-  // Find or generate the next layout
+  const layout = cloneLayout(orgLayout || []);
 
   return compactLayout(correctBounds(layout, { cols }, distributeEvenly), verticalCompact);
 };


### PR DESCRIPTION
# Description

Added check in responsiveGridLayout if the function is called by a window resize if so check if a layout was already cached that we can fall back on.

This check should not trigger for example when the user is manually changing the position of the items.

There might be a more elegant solution to this but i am not familiar enough with the code base yet.

Fixes #54  (issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- tested in the sandbox by resizing multiple times with different item quantity with responsive layout on.
- tested item positioning so it should work as expected

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
