### PR TITLE
Change placeholder index to a string identifier

### DIFF
--- a/src/components/Grid/GridLayout.vue
+++ b/src/components/Grid/GridLayout.vue
@@ -143,7 +143,7 @@
   const isDragging = ref<boolean>(false);
   const placeholder = ref<IPlaceholder>({
     h: 0,
-    i: -1,
+    i: '__grid_placeholder__',
     w: 0,
     x: 0,
     y: 0,


### PR DESCRIPTION
Fixes Error: Invalid parameter layoutItem id passed

# Description

-1 is invalid id, it must be string or greater then 0.

Fixes # [(issue)](https://github.com/gwinnem/vue-responsive-grid-layout/issues/65)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Opening dashboard in edit mode

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
